### PR TITLE
fix: duplicate documents issue

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -139,32 +139,17 @@ export async function POST(request: Request) {
     const chat = await getChatById({ id });
 
     if (!chat) {
-      // Save chat immediately with a temporary title to avoid blocking
+      const title = await generateTitleFromUserMessage({
+        message,
+        titleModel: provider.languageModel('title-model'),
+      });
+
+      // Update chat with generated title
       await saveChat({
         id,
         userId: session.user.id,
-        title: 'New Chat', // Temporary title
+        title,
         visibility: selectedVisibilityType,
-      });
-
-      // Generate title in background and update chat
-      after(async () => {
-        try {
-          const title = await generateTitleFromUserMessage({
-            message,
-            titleModel: provider.languageModel('title-model'),
-          });
-
-          // Update chat with generated title
-          await saveChat({
-            id,
-            userId: session.user.id,
-            title,
-            visibility: selectedVisibilityType,
-          });
-        } catch (error) {
-          console.error('Failed to generate and update chat title:', error);
-        }
       });
     } else {
       if (chat.userId !== session.user.id) {

--- a/app/(chat)/profile/page.tsx
+++ b/app/(chat)/profile/page.tsx
@@ -1,10 +1,17 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@/app/(auth)/auth';
-import { ProfileTabs } from '@/components/profile-tabs';
 import { AccountTab } from '@/components/profile/account-tab';
 import { LinkingTab } from '@/components/profile/linking-tab';
 import { ProfileHeader } from '@/components/profile-header';
 import { getUserTelegramLink } from '@/lib/db/queries/link/telegram';
+import dynamic from 'next/dynamic';
+
+const ProfileTabs = dynamic(
+  () => import('@/components/profile-tabs').then((mod) => mod.ProfileTabs),
+  {
+    ssr: !!false,
+  },
+);
 
 interface ProfilePageProps {
   searchParams: Promise<{ tab?: string }>;

--- a/lib/ai/tools/search-documents.spec.ts
+++ b/lib/ai/tools/search-documents.spec.ts
@@ -75,16 +75,8 @@ describe('searchDocumentsTool', () => {
     });
 
     expect(result).toEqual({
-      message: 'Found 2 document(s) matching your search query.',
+      message: 'Found 1 document(s) matching your search query.',
       results: [
-        {
-          id: 'doc-1',
-          originalFileName: 'test.pdf',
-          mimeType: 'application/pdf',
-          size: 1024,
-          createdAt: mockDocuments[0].createdAt,
-          content: 'This is a test document content',
-        },
         {
           id: 'doc-1',
           originalFileName: 'test.pdf',

--- a/lib/ai/tools/search-documents.ts
+++ b/lib/ai/tools/search-documents.ts
@@ -67,13 +67,22 @@ export const searchDocumentsTool = ({ session }: SearchDocumentsProps) =>
           };
         }
 
+        // Merge private and public documents, dropping duplicates by id
+        const mergedDocuments = [
+          ...privateDocuments,
+          ...publicDocuments.filter(
+            (pubDoc) =>
+              !privateDocuments.some((privDoc) => privDoc.id === pubDoc.id),
+          ),
+        ];
+
         const message = documentId
-          ? `Found ${privateDocuments.length + publicDocuments.length} relevant section(s) in the document matching your search query.`
-          : `Found ${privateDocuments.length + publicDocuments.length} document(s) matching your search query.`;
+          ? `Found ${mergedDocuments.length} relevant section(s) in the document matching your search query.`
+          : `Found ${mergedDocuments.length} document(s) matching your search query.`;
 
         return {
           message,
-          results: [...privateDocuments, ...publicDocuments].map((doc) => ({
+          results: mergedDocuments.map((doc) => ({
             id: doc.id,
             originalFileName: doc.originalFileName,
             mimeType: doc.mimeType,

--- a/lib/db/queries/vector-store.spec.ts
+++ b/lib/db/queries/vector-store.spec.ts
@@ -21,7 +21,7 @@ import {
 } from './vector-store';
 import { createUser, deleteUserAccount } from './queries';
 import { ChatSDKError } from '@/lib/errors';
-import type { VectorStoreDocument } from '../schema';
+import { vectorStoreDocument, VectorStoreDocument } from '../schema';
 import { generateRandomTestUser } from '@/tests/helpers';
 
 /**
@@ -45,6 +45,10 @@ const createMockVectorStoreDocument = (
   ...overrides,
 });
 
+async function cleanUpDatabase() {
+  await db.delete(vectorStoreDocument);
+}
+
 describe('Vector Store Queries', () => {
   let testUserId: string;
 
@@ -52,6 +56,7 @@ describe('Vector Store Queries', () => {
    * Creates a test user before each test
    */
   beforeEach(async () => {
+    await cleanUpDatabase();
     const user = generateRandomTestUser();
     const [testUser] = await createUser(user.email, user.password);
     testUserId = testUser.id;
@@ -683,14 +688,7 @@ describe('Vector Store Queries', () => {
     });
 
     afterEach(async () => {
-      // Clean up all created documents and users
-      if (allDocIds.length > 0) {
-        await deleteDocumentsByIds({ ids: allDocIds });
-        allDocIds = [];
-      }
-      if (testUser2Id) {
-        await deleteUserAccount({ id: testUser2Id });
-      }
+      await cleanUpDatabase();
     });
 
     test('should return own documents and public documents from others', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Chat titles are now generated immediately from the user's message, ensuring more relevant titles appear instantly when starting a new chat.
  - Search results from private and public documents are now merged to remove duplicates, providing a cleaner and more accurate list of documents.
  - Profile tabs now load dynamically for improved performance and client-side rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->