### PR TITLE
fix: add workflow abort support

### DIFF
--- a/artifacts/flowchart/server.ts
+++ b/artifacts/flowchart/server.ts
@@ -27,12 +27,19 @@ export const flowchartDocumentHandler = (
         abortController.abort();
       });
 
-      const workflow = await agent(query, null, userContext, {}, (step) => {
-        dataStream.writeData({
-          type: 'flowchart-step-delta',
-          content: JSON.stringify(step, null, 2),
-        });
-      });
+      const workflow = await agent(
+        query,
+        null,
+        userContext,
+        {},
+        (step) => {
+          dataStream.writeData({
+            type: 'flowchart-step-delta',
+            content: JSON.stringify(step, null, 2),
+          });
+        },
+        abortController.signal,
+      );
 
       dataStream.writeData({
         type: 'flowchart-delta',
@@ -57,6 +64,11 @@ export const flowchartDocumentHandler = (
       } catch {}
 
       const userContext = await getUserContext(session.user.id);
+      const abortController = new AbortController();
+
+      dataStream.onError?.(() => {
+        abortController.abort();
+      });
 
       const workflowResult = await agent(
         description,
@@ -69,6 +81,7 @@ export const flowchartDocumentHandler = (
             content: JSON.stringify(step, null, 2),
           });
         },
+        abortController.signal,
       );
       const draftContent = JSON.stringify(workflowResult, null, 2);
 

--- a/lib/workflow/state/upstash.ts
+++ b/lib/workflow/state/upstash.ts
@@ -13,8 +13,9 @@ export class UpStashStateClient implements StateClient {
 
   constructor(private readonly namespace: string = 'default') {
     this.client = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL,
-      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+      url: process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL,
+      token:
+        process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN,
     });
   }
   async getAllState(

--- a/lib/workflow/workflow-tools.ts
+++ b/lib/workflow/workflow-tools.ts
@@ -441,7 +441,7 @@ export const viewWorkflow = (workflow: Workflow) =>
     description: 'View workflow in json',
     parameters: z.object({}),
     execute: async () => {
-      return workflow.getWorkflow();
+      return workflow.toViewableString();
     },
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for cancelling workflow operations, allowing ongoing processes to be stopped if needed.
- **Improvements**
	- Enhanced reliability of workflow streaming by handling client disconnects and errors more gracefully.
	- The workflow viewing tool now presents workflows in a more readable, user-friendly format.
	- Improved environment variable handling for state storage, providing better fallback options for configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->